### PR TITLE
Template `spack.yaml`/`config/versions.json` Update

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
-    "spack": "0.21",
+    "spack": "0.22",
     "spack-packages": "SOME_SPECIFIC_TAG",
     "spack-config": "SOME_SPECIFIC_TAG"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,8 +18,9 @@ spack:
     # Specifications that apply to all packages
     all:
       # TODO: Specify compiler/targets for all packages
-      # compiler: [intel@19.0.5.281]
-      # target: [x86_64]
+      # require:
+      #   - '%intel@19.0.5.281'
+      #   - 'target=x86_64'
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
In this PR:
* Use the explicit `spack.packages.all.require` syntax for compilers and targets rather then the preference `spack.packages.all.compiler`/`spack.packages.all.target`. 
* Use the `0.22` spack as a default rather then `0.21`. 