### PR TITLE
Include info on Multi-Target `spack.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Regarding the secrets and variables that must be created:
 
 There are a few TODOs for the `spack.yaml`:
 
+* Only do this step if there are variations in compiler/etc across deployment targets:
+  * `spack.definitions`: Use the `ROOT_PACKAGE` to define the root SBD. The `ROOT_SPEC` simply combines the `ROOT_PACKAGE` with the other, mutually-exclusive `compiler_target` definition.
+  * `spack.specs`: Set the only element in the spec list to `$ROOT_SPEC` - it will be filled in at install time.
+
+Otherwise:
+
 * `spack.specs`: Set the root SBD as the only element of `spack.specs`. This must also have an `@git.YEAR.MONTH.MINOR` version as it is the version of the entire deployment (and indeed will be a tag in this repository).
 * `spack.packages.*`: In this section, you can specify the versions and variants of dependencies. Note that the first element of the `spack.packages.*.require` must be only a version. Variants and other configuration can be done on subsequent lines.
 * `spack.packages.all`: Can set configuration for all packages. For example, the compiler used, or the target architecture.

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,11 +3,35 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
+  # TODO: This section is used primarily to provide variations to a model based on deployment target. Delete if not required.
+  # definitions:
+    # This is the root spack bundle that contains the model
+    # - ROOT_PACKAGE:
+    #   - MODEL@git.VERSION
+
+    # Mutually-exclusive Compiler and Target definitions (assumes DEPLOYMENT_TARGET set)
+    # - when: env['DEPLOYMENT_TARGET'] == 'Gadi'
+    #   compiler_target: ['%intel@19.0.5.281 target=x86_64_v4']
+    # More mutually-exclusive definitions can be made...
+    # Default
+    # - when: "'DEPLOYMENT_TARGET' not in env"
+    #   compiler_targets: ['intel@2021.2.0 target=x86_64']
+
+    # This is where the single definitions of ROOT_PACKAGE and compiler/target are
+    # matrixed together to form a single spec: MODEL@git.VERSION %intel@2021.2.0 target=x86_64
+    # - ROOT_SPEC:
+    #   - matrix:
+    #     - [$ROOT_PACKAGE]
+    #     - [$%compiler_target]
+
   specs:
     # The root Spack Bundle Recipe (SBR) for the model and overall version of
     # the deployment:
-    # TODO: Replace the MODEL and VERSION.
+    # TODO: Replace the MODEL and VERSION, if there is only one deployment target
     # - MODEL@git.VERSION
+    # Alternatively, if there are multiple deployment targets that require
+    # different compilers/variants, use the above definitions section and:
+    # - $ROOT_SPEC
   packages:
     # Specification of dependency versions and variants. CI/CD requires that
     # the first element of the require is only a version:


### PR DESCRIPTION
References #15

## Background

This PR gives instructions on how to defintion variations on the model depending on where it was deployed. 

In this PR:

* Update `spack.yaml` to note usage of the `definitions` section
* Update `README.md` to give instruction on using `spack.specs[0] == "MODEL@git.VERSION` vs `spack.specs[0] == $ROOT_SPEC`
