### PR TITLE
Update Instructions On Model Deployment Repo Deployment Target Choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ There are a few secrets and variables that must be set at the repository level.
 * `NAME`: which corresponds to the model name - which is usually the repository name
 * `CONFIG_VERSIONS_SCHEMA_VERSION`: Version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions) used in this repository
 * `SPACK_YAML_SCHEMA_VERSION`: Version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment) used in this repository
+* `RELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing release deployments. These are often the names of [keys under the `deployment` key of `build-cd`s `config/settings.json`](https://github.com/ACCESS-NRI/build-cd/blob/09cdf100eefc58f06900e8e9145e77b4caf5a39d/config/settings.json#L3), such as `Gadi` or `Setonix`. As noted [below](#environment-secretsvariables), it is the same as the GitHub Environment name. For example: `Gadi Setonix`
+* `PRERELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing prerelease deployments, similar to the above. For example: `Gadi Setonix` - note the lack of a `Prerelease` specifier!
 
 #### Environment Secrets/Variables
 

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
+    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
     "spack-packages": "SOME_SPECIFIC_TAG"
 }


### PR DESCRIPTION
References ACCESS-NRI/build-cd#209

## Background

See related PR ACCESS-NRI/build-cd#211. This one updates the instructions with the two new `vars` that are required. 

In this PR:

- **Updated config/versions.json to use raw.githubusercontent schema**
- **README.md: Added info on two new required repo-level vars, [PRE]RELEASE_DEPLOYMENT_TARGETS**
