### PR TITLE
Update Instructions for `=VERSION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ There are a few TODOs for the `spack.yaml`:
 Otherwise:
 
 * `spack.specs`: Set the root SBD as the only element of `spack.specs`. This must also have an `@git.YEAR.MONTH.MINOR` version as it is the version of the entire deployment (and indeed will be a tag in this repository).
+
+Then:
+
 * `spack.packages.*`: In this section, you can specify the versions and variants of dependencies. Note that the first element of the `spack.packages.*.require` must be only a version. Variants and other configuration can be done on subsequent lines.
 * `spack.packages.all`: Can set configuration for all packages. For example, the compiler used, or the target architecture.
 * `spack.modules.default.tcl.include`: List of package names that will be explicitly included and available to `module load`.

--- a/spack.yaml
+++ b/spack.yaml
@@ -36,6 +36,11 @@ spack:
     # Specification of dependency versions and variants. CI/CD requires that
     # the first element of the require is only a version:
     # TODO: Specify versions and variants of dependencies as required.
+    # model-component:
+    #   require:
+    #     # Where VERSION below is usually the MODEL defined above - it's used by spack 
+    #     # packages to define model-specific behavior for built components
+    #     - '@git.REF=VERSION'
     # openmpi:
     #   require:
     #     - '@4.1.5'


### PR DESCRIPTION
Relevant to https://github.com/ACCESS-NRI/ACCESS-OM2/pull/96

In this PR:

- **Split multi/single-target instructions more effectively**
- **Updated instruction for =VERSION sections**
