### PR TITLE
Remove references to the now-injected Projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ There are a few secrets and variables that must be set at the repository level.
 ##### Repository Secrets
 
 * `GH_COMMIT_CHECK_TOKEN`: GitHub Token that allows workflows to run based on workflow-authored commits (in  the case where a user uses `!bump` commands in PRs that bumps the version of the model)
+* `TRACKING_SERVICES_POST_TOKEN`: A token used to post build information about the packages in `secrets.BUILD_DB_PACKAGES` to the release provenance database as part of tracking services, used for Releases.
+
 
 ##### Repository Variables
 
@@ -29,6 +31,7 @@ There are a few secrets and variables that must be set at the repository level.
 * `SPACK_YAML_SCHEMA_VERSION`: Version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment) used in this repository
 * `RELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing release deployments. These are often the names of [keys under the `deployment` key of `build-cd`s `config/settings.json`](https://github.com/ACCESS-NRI/build-cd/blob/09cdf100eefc58f06900e8e9145e77b4caf5a39d/config/settings.json#L3), such as `Gadi` or `Setonix`. As noted [below](#environment-secretsvariables), it is the same as the GitHub Environment name. For example: `Gadi Setonix`
 * `PRERELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing prerelease deployments, similar to the above. For example: `Gadi Setonix` - note the lack of a `Prerelease` specifier!
+* `TRACKING_SERVICES_POST_URL`: A url to the API of the release provenance database as part of tracking services, used for Releases. 
 
 #### Environment Secrets/Variables
 
@@ -51,7 +54,6 @@ Regarding the secrets and variables that must be created:
 * `HOST_DATA`: The deployment location SSH Host for data transfer (may be the same as `HOST`)
 * `SSH_KEY`: A SSH Key that allows access to the above `HOST`/`HOST_DATA`
 * `USER`: A Username to login to the above `HOST`/`HOST_DATA`
-* (Required only for `Release` Environment) `TRACKING_SERVICES_POST_TOKEN`: A token used to post build information about the packages in `secrets.BUILD_DB_PACKAGES` to the release provenance database as part of tracking services. 
 
 ##### Environment Variables
 
@@ -60,7 +62,6 @@ Regarding the secrets and variables that must be created:
 * `SPACK_INSTALLS_ROOT_LOCATION`: Path to the directory that contains all versions of a deployment of `spack`. For example, if `/some/apps/spack` is the `SPACK_INSTALLS_ROOT_LOCATION`, that directory will contain directories like `0.20`, `0.21`, `0.22`, which in turn contain an install of `spack`, `spack-packages` and `spack-config`
 * `SPACK_YAML_LOCATION`: Path to a directory that will contain the `spack.yaml` from this repository during deployment
 * (Optional) `SPACK_INSTALL_ADDITIONAL_ARGS`: Additional flags outside of `--fresh --fail-fast` to add to the `spack install` command. For advanced users who need to tailor the installation options in their repository.
-* (Required only for `Release` Environment) `TRACKING_SERVICES_POST_URL`: A url to the API of the release provenance database as part of tracking services. 
 
 ### File Modifications
 
@@ -88,4 +89,3 @@ Otherwise:
 * `spack.packages.*`: In this section, you can specify the versions and variants of dependencies. Note that the first element of the `spack.packages.*.require` must be only a version. Variants and other configuration can be done on subsequent lines.
 * `spack.packages.all`: Can set configuration for all packages. For example, the compiler used, or the target architecture.
 * `spack.modules.default.tcl.include`: List of package names that will be explicitly included and available to `module load`.
-* `spack.modules.default.tcl.projections`: For included modules, you must set the name of the module to be the same as the `spack.packages.*.require[0]` version, without the `@git.`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ There are a few secrets and variables that must be set at the repository level.
 * `GH_COMMIT_CHECK_TOKEN`: GitHub Token that allows workflows to run based on workflow-authored commits (in  the case where a user uses `!bump` commands in PRs that bumps the version of the model)
 * `TRACKING_SERVICES_POST_TOKEN`: A token used to post build information about the packages in `secrets.BUILD_DB_PACKAGES` to the release provenance database as part of tracking services, used for Releases.
 
-
 ##### Repository Variables
 
 * `BUILD_DB_PACKAGES`: List of `spack` packages that are model components that will be uploaded to the release provenance database
@@ -31,7 +30,7 @@ There are a few secrets and variables that must be set at the repository level.
 * `SPACK_YAML_SCHEMA_VERSION`: Version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment) used in this repository
 * `RELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing release deployments. These are often the names of [keys under the `deployment` key of `build-cd`s `config/settings.json`](https://github.com/ACCESS-NRI/build-cd/blob/09cdf100eefc58f06900e8e9145e77b4caf5a39d/config/settings.json#L3), such as `Gadi` or `Setonix`. As noted [below](#environment-secretsvariables), it is the same as the GitHub Environment name. For example: `Gadi Setonix`
 * `PRERELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing prerelease deployments, similar to the above. For example: `Gadi Setonix` - note the lack of a `Prerelease` specifier!
-* `TRACKING_SERVICES_POST_URL`: A url to the API of the release provenance database as part of tracking services, used for Releases. 
+* `TRACKING_SERVICES_POST_URL`: A url to the API of the release provenance database as part of tracking services, used for Releases.
 
 #### Environment Secrets/Variables
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,14 +50,9 @@ spack:
   view: true
   concretizer:
     unify: true
-  modules:
-    default:
-      tcl:
-        include:
-          # TODO: Add MODEL and PACKAGEs that will have a corresponding module
-          # - MODEL
-          # - PACKAGE1
-          # - PACKAGE2
+  # modules:
+  #   overridden module includes, projections, etc, if needed
+  #   we inject these in build-cd now, but custom ones can be added additionally here
   # config:
   #   overridden spack configurations, if needed
   # mirrors:

--- a/spack.yaml
+++ b/spack.yaml
@@ -58,20 +58,6 @@ spack:
           # - MODEL
           # - PACKAGE1
           # - PACKAGE2
-        projections:
-          # These projection GIT_REFs must be the same as the
-          # `spack.packages.*.require[0]` ref but without the `@git.`
-          # and without the '=SPACK_VERSION', if there is one.
-          #
-          # For a MODEL, an example projection is `{name}/2024.10.0`.
-          # For a PACKAGE where `require` @git.GIT_REF=SPACK_VERSION is
-          # `@git.2024.04.21=access-esm1.5`, the projection becomes
-          # `{name}/2024.04.21-{hash:7}`.
-          # TODO: Add explicit projections for modules that will be found with
-          #       `module load`.
-          # MODEL: '{name}/VERSION'
-          # PACKAGE1: '{name}/VERSION1-{hash:7}'
-          # PACKAGE2: '{name}/VERSION2-{hash:7}'
   # config:
   #   overridden spack configurations, if needed
   # mirrors:


### PR DESCRIPTION
References ACCESS-NRI/build-cd#169
References ACCESS-NRI/build-cd#276
Requires ACCESS-NRI/build-cd#295

## Background

In ACCESS-NRI/build-cd#295, users will no longer be required to create or edit their own projections in spack manifests. Therefore, we are removing the guidance on projections entirely, to keep it simple. 

## Open Question

* Should there still be some guidance on projections?

## The PR

* Remove all references to projections in the `spack.yaml`, and in the `README.md`
* Also shuffled around some `TRACKING_SERVICES_*` variable stuff - they're meant to be repo secrets/vars, not environment ones!
