### PR TITLE
Template Update For Infra Update `v6`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Tommy needs to review changes to infra
+/.github/ @CodeGat
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,13 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v5
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v6
     with:
       model: ${{ vars.NAME }}
+      # TODO: Get versions of applicable schema from ACCESS-NRI/schema
+      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE
+      config-versions.schema-version: SET_SCHEMA_VERSION_HERE
+      config-packages-schema-version: SET_SCHEMA_VERSION_HERE
     permissions:
       contents: write
       # This is due to the entrypoint also handling `on.pull_request` events

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
       model: ${{ vars.NAME }}
       # TODO: Get versions of applicable schema from ACCESS-NRI/schema
       spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE
-      config-versions.schema-version: SET_SCHEMA_VERSION_HERE
+      config-versions-schema-version: SET_SCHEMA_VERSION_HERE
       config-packages-schema-version: SET_SCHEMA_VERSION_HERE
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,10 +13,10 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@v6
     with:
       model: ${{ vars.NAME }}
-      # TODO: Get versions of applicable schema from ACCESS-NRI/schema
-      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment
-      config-versions-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions
-      config-packages-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages
+      # TODO: Check versions are appropriate
+      spack-manifest-schema-version: 1-0-7
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
     permissions:
       contents: write
       # This is due to the entrypoint also handling `on.pull_request` events

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,9 +14,9 @@ jobs:
     with:
       model: ${{ vars.NAME }}
       # TODO: Get versions of applicable schema from ACCESS-NRI/schema
-      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE
-      config-versions-schema-version: SET_SCHEMA_VERSION_HERE
-      config-packages-schema-version: SET_SCHEMA_VERSION_HERE
+      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment
+      config-versions-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions
+      config-packages-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages
     permissions:
       contents: write
       # This is due to the entrypoint also handling `on.pull_request` events

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
-     # TODO: Get versions of applicable schema from ACCESS-NRI/schema
-      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment
-      config-versions-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions
-      config-packages-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages
+     # TODO: Check versions are appropriate
+      spack-manifest-schema-version: 1-0-7
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
      # TODO: Get versions of applicable schema from ACCESS-NRI/schema
       spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE
-      config-versions.schema-version: SET_SCHEMA_VERSION_HERE
+      config-versions-schema-version: SET_SCHEMA_VERSION_HERE
       config-packages-schema-version: SET_SCHEMA_VERSION_HERE
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
      # TODO: Get versions of applicable schema from ACCESS-NRI/schema
-      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE
-      config-versions-schema-version: SET_SCHEMA_VERSION_HERE
-      config-packages-schema-version: SET_SCHEMA_VERSION_HERE
+      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment
+      config-versions-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions
+      config-packages-schema-version: SET_SCHEMA_VERSION_HERE  # https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,15 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' && github.event.action != 'closed') ||
       (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v6
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+     # TODO: Get versions of applicable schema from ACCESS-NRI/schema
+      spack-manifest-schema-version: SET_SCHEMA_VERSION_HERE
+      config-versions.schema-version: SET_SCHEMA_VERSION_HERE
+      config-packages-schema-version: SET_SCHEMA_VERSION_HERE
     permissions:
       pull-requests: write
       contents: write
@@ -40,7 +44,7 @@ jobs:
   pr-comment:
     name: Comment
     if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v6
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -52,7 +56,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v6
     with:
       root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Regarding the secrets and variables that must be created:
 #### In `.github/CODEOWNERS`
 
 * By default, @CodeGat will be pinged for review for infrastructure changes.
-* Maintainers can set CODEOWNERs of the `spack.yaml` manifest so they are pinged when changes are proposed to that file.
+* Maintainers should set CODEOWNERs of the `spack.yaml` manifest to ensure all affected teams are consulted when changes are proposed to that file.
 
 #### In `spack.yaml`
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ There are a few secrets and variables that must be set at the repository level.
 ##### Repository Variables
 
 * `NAME`: which corresponds to the model name - which is usually the repository name
-* `CONFIG_VERSIONS_SCHEMA_VERSION`: Version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions) used in this repository
-* `CONFIG_PACKAGES_SCHEMA_VERSION`: Version of the [`config/packages.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages) used in this repository
-* `SPACK_YAML_SCHEMA_VERSION`: Version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment) used in this repository
 * `RELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing release deployments. These are often the names of [keys under the `deployment` key of `build-cd`s `config/settings.json`](https://github.com/ACCESS-NRI/build-cd/blob/09cdf100eefc58f06900e8e9145e77b4caf5a39d/config/settings.json#L3), such as `Gadi` or `Setonix`. As noted [below](#environment-secretsvariables), it is the same as the GitHub Environment name. For example: `Gadi Setonix`
 * `PRERELEASE_DEPLOYMENT_TARGETS`: Space-separated list of deployment targets when doing prerelease deployments, similar to the above. For example: `Gadi Setonix` - note the lack of a `Prerelease` specifier!
 * `TRACKING_SERVICES_POST_URL`: A url to the API of the release provenance database as part of tracking services, used for Releases.
@@ -68,6 +65,9 @@ Regarding the secrets and variables that must be created:
 
 * Reminder that these workflows use `vars.NAME` (as well as inherit the above environment secrets) and hence these must be set.
 * If the name of the root SBD for the model (in [`spack-packages`](https://github.com/ACCESS-NRI/spack-packages/tree/main/packages)) is different from the model name (for example, `ACCESS-ESM1.5`s root SBD is `access-esm1p5`), you must uncomment and set the `jobs.[pr-ci|pr-comment|pr-closed].with.root-sbd` line to the appropriate SBD name.
+* Set `inputs.config-versions-schema-version` to an appropriate version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions).
+* Set `inputs.config-packages-schema-version` to an appropriate version of the [`config/packages.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages).
+* Set `inputs.spack-manifest-schema-version` to an appropriate version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment).
 
 #### In `config/versions.json`
 
@@ -78,6 +78,11 @@ Regarding the secrets and variables that must be created:
 
 * `.provenance`: If components of a model are to be kept track of in the release provenance database, their package names must be added to this list. They will also be injected into the `spack.modules.tcl.default` section of the manifest.
 * `.injection`: If packages need to be injected automatically in the manifest, their package names must be added to this list.
+
+#### In `.github/CODEOWNERS`
+
+* By default, @CodeGat will be pinged for review for infrastructure changes.
+* Maintainers can set CODEOWNERs of the `spack.yaml` manifest so they are pinged when changes are proposed to that file.
 
 #### In `spack.yaml`
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Regarding the secrets and variables that must be created:
 
 * Reminder that these workflows use `vars.NAME` (as well as inherit the above environment secrets) and hence these must be set.
 * If the name of the root SBD for the model (in [`spack-packages`](https://github.com/ACCESS-NRI/spack-packages/tree/main/packages)) is different from the model name (for example, `ACCESS-ESM1.5`s root SBD is `access-esm1p5`), you must uncomment and set the `jobs.[pr-ci|pr-comment|pr-closed].with.root-sbd` line to the appropriate SBD name.
-* Set `inputs.config-versions-schema-version` to an appropriate version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions).
-* Set `inputs.config-packages-schema-version` to an appropriate version of the [`config/packages.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages).
-* Set `inputs.spack-manifest-schema-version` to an appropriate version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment).
+* Check `inputs.config-versions-schema-version` is an appropriate version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions).
+* Check `inputs.config-packages-schema-version` is an appropriate version of the [`config/packages.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages).
+* Check `inputs.spack-manifest-schema-version` is an appropriate version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment).
 
 #### In `config/versions.json`
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,31 @@ A template repository for the deployment of `spack`-based models.
 > [!NOTE]
 > Feel free to replace this README with information on the model once the TODOs have been ticked off.
 
+## Common README.md Elements
+
+### Badges for spack, spack-packages, spack-config used
+
+If you want to add badges for the current version of [`spack`](https://github.com/ACCESS-NRI/spack) and [`spack-packages`](https://github.com/ACCESS-NRI/spack-packages) used for the latest model deployment, and the latest version of [`spack-config`](https://github/ACCESS-NRI/spack-config) used across all models, you can add the following urls to your README.
+
+> [!NOTE]
+> The first two URLS (`spack` and `spack-packages`) must have the repository name rather than `__MODEL__` (eg, `ACCESS-OM3`), so it can pull data from that repository. The last one (`spack-config`) pulls from a central `build-cd` repository and doesn't need to be edited.
+
+```txt
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FACCESS-NRI%2F__MODEL__%2Fraw%2Fmain%2Fconfig%2Fversions.json&query=%24.spack-packages&label=ACCESS-NRI%2Fspack-packages)
+
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FACCESS-NRI%2F__MODEL__%2Fraw%2Fmain%2Fconfig%2Fversions.json&query=%24.spack&label=ACCESS-NRI%2Fspack)
+
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FACCESS-NRI%2Fbuild-cd%2Fraw%2FHEAD%2Fconfig%2Fsettings.json&query=%24.deployment.Gadi.Release.%5B'0.22'%5D.spack-config&label=ACCESS-NRI%2Fspack-config%20(Gadi))
+```
+
+If done correctly, they will look something like this (`ACCESS-OM3` example):
+
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FACCESS-NRI%2FACCESS-OM3%2Fraw%2Fmain%2Fconfig%2Fversions.json&query=%24.spack-packages&label=ACCESS-NRI%2Fspack-packages)
+
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FACCESS-NRI%2FACCESS-OM3%2Fraw%2Fmain%2Fconfig%2Fversions.json&query=%24.spack&label=ACCESS-NRI%2Fspack)
+
+![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2FACCESS-NRI%2Fbuild-cd%2Fraw%2FHEAD%2Fconfig%2Fsettings.json&query=%24.deployment.Gadi.Release.%5B'0.22'%5D.spack-config&label=ACCESS-NRI%2Fspack-config%20(Gadi))
+
 ## Things TODO to get your model deployed
 
 ### Settings


### PR DESCRIPTION
References https://github.com/ACCESS-NRI/build-cd/issues/311
Closes #34 

## Background

We need to update instructions for the `v6` rollout.

We also add fancy badges so users know what versions of `spack`/`spack-config`/`spack-packages` is currently being used by a given model. 

## The PR

* Update template infra to `v6`
* Add default CODEOWNERs file
* Update instructions
* Add fancy badges
