### PR TITLE
Update Guidance for `v8` - `spack v1` Migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Tommy needs to review changes to infra
 /.github/ @CodeGat
-

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
       # TODO: Check versions are appropriate

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,11 +8,9 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
-      pr: ${{ github.event.issue.number }}
       # TODO: Check versions are appropriate
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
@@ -25,10 +23,9 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
     permissions:
       pull-requests: write
       contents: write
@@ -36,10 +33,9 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
       auto-configs-pr-schema-version: 1-0-0
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
-      pr: ${{ github.event.pull_request.number }}
      # TODO: Check versions are appropriate
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
@@ -39,6 +37,4 @@ jobs:
     name: Closed
     if: github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
-    with:
-      root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -38,7 +38,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Regarding the secrets and variables that must be created:
 #### In `.github/workflows`
 
 * Reminder that these workflows use `vars.NAME` (as well as inherit the above environment secrets) and hence these must be set.
-* If the name of the root SBD for the model (in [`spack-packages`](https://github.com/ACCESS-NRI/spack-packages/tree/main/packages)) is different from the model name (for example, `ACCESS-ESM1.5`s root SBD is `access-esm1p5`), you must uncomment and set the `jobs.*.with.root-sbd` line to the appropriate SBD name, for all `.github/workflows/*.yml` files.
 * Check `inputs.config-versions-schema-version` is an appropriate version of the [`config/versions.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/versions).
 * Check `inputs.config-packages-schema-version` is an appropriate version of the [`config/packages.json` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/deployment/config/packages).
 * Check `inputs.spack-manifest-schema-version` is an appropriate version of the [ACCESS-NRI-style `spack.yaml` schema](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/spack/environment/deployment).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Regarding the secrets and variables that must be created:
 #### In `config/versions.json`
 
 * `.spack` must be given a version. For example, it will clone the associated `releases/vVERSION` branch of `ACCESS-NRI/spack` if you give it `VERSION`.
-* `.spack-packages` should also have a CalVer-compliant tag as the version. See the [associated repo](https://github.com/ACCESS-NRI/spack-packages/tags) for a list of available tags.
+* `.access-spack-packages` should also have a CalVer-compliant tag as the version. See the [associated repo](https://github.com/ACCESS-NRI/access-spack-packages/tags) for a list of available tags.
+* Optionally, a list of `.custom-scopes` can be specified from `spack-config`s `custom/cd/` - this is usually for restricted builds.
 
 #### In `config/packages.json`
 
@@ -167,6 +168,7 @@ There are a few TODOs for the `spack.yaml`:
 
 Otherwise:
 
-* `spack.specs`: Set the root SBD as the only element of `spack.specs`. This must also have an `@git.YEAR.MONTH.MINOR` version as it is the version of the entire deployment (and indeed will be a tag in this repository).
-* `spack.packages.*`: In this section, you can specify the versions and variants of dependencies. Note that the first element of the `spack.packages.*.require` must be only a version. Variants and other configuration can be done on subsequent lines.
+* `spack.definitions`: Set both the `_name` and `_version` reserved variants, which give the deployment it's name and version.
+* `spack.specs`: Set the root SBD as the only element of `spack.specs`.
+* `spack.packages.*`: In this section, you can specify the versions and variants of dependencies and compilers. Note that the first element of the `spack.packages.*.require` must be only a version. Variants and other configuration can be done on subsequent lines.
 * `spack.packages.all`: Can set configuration for all packages. For example, the compiler used, or the target architecture.

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-    "spack": "0.22",
+    "spack": "1.1",
     "access-spack-packages": "SOME_SPECIFIC_TAG",
     "custom-scopes": []
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,6 @@
 {
-    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
+    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
     "spack": "0.22",
-    "spack-packages": "SOME_SPECIFIC_TAG"
+    "access-spack-packages": "SOME_SPECIFIC_TAG",
+    "custom-scopes": []
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,8 +3,12 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
-  # TODO: This section is used primarily to provide variations to a model based on deployment target. Delete if not required.
   # definitions:
+    # TODO: _name and _version are required reserved definitions that inform build-cd deployments, and have no effect otherwise
+    # - _name: [DEPLOYMENT_NAME_HERE]
+    # - _version: [DEPLOYMENT_VERSION_HERE]
+
+    # TODO: This section is used primarily to provide variations to a model based on deployment target. Delete if not required.
     # This is the root spack bundle that contains the model
     # - ROOT_PACKAGE:
     #   - MODEL@git.GIT_REF=SPACK_VERSION
@@ -25,11 +29,9 @@ spack:
     #     - [$%compiler_target]
 
   specs:
-    # The root Spack Bundle Recipe (SBR) for the model and overall version of
-    # the deployment:
-    # TODO: Replace the MODEL, GIT_REF and SPACK_VERSION, if there is
-    #       only one deployment target
-    # - MODEL@git.GIT_REF=SPACK_VERSION
+    # The root Spack Bundle Recipe (SBR) for the model
+    # TODO: Replace the MODEL if there is only one deployment target
+    # - MODEL
     # Alternatively, if there are multiple deployment targets that require
     # different compilers/variants, use the above definitions section and:
     # - $ROOT_SPEC
@@ -39,14 +41,18 @@ spack:
     # TODO: Specify versions and variants of dependencies as required.
     # openmpi:
     #   require:
-    #     - '@4.1.5'
+    #   - '@4.1.5'
+
+    # Compilers
+    # TODO: For compilers used in this deployment, specify versions as required.
+    #       If changing compiler families, don't forget to update the 'all' section below.
 
     # Specifications that apply to all packages
     all:
-      # TODO: Specify compiler/targets for all packages
+      # TODO: Specify compiler toolchain/targets for all packages
       # require:
-      #   - '%intel@2021.10.0'
-      #   - 'target=x86_64'
+      # - '%access_intel'
+      # - 'target=x86_64'
   view: true
   concretizer:
     unify: true
@@ -54,7 +60,8 @@ spack:
   #   overridden module includes, projections, etc, if needed
   #   we inject these in build-cd now, but custom ones can be added additionally here
   # config:
-  #   overridden spack configurations, if needed
+  #   overridden spack configurations, if needed. Preference is to use custom configurations scopes in
+  #   spack-config's custom/cd/SCOPE, referenced in the config/versions.json's custom-scopes field.
   # mirrors:
   #   overridden spack package tarball directories, if needed
   # repos:


### PR DESCRIPTION
References https://github.com/ACCESS-NRI/build-cd/pull/326
Closes #36

## Background

This PR updates `model-deployment-template` guidance for `build-cd v8` - the `spack v1.X` migration. It includes:

* The new `spack.yaml` reserved definitions `.spack.definitions[].{_name|_version}`
* The new optional `config/versions.json` field `.custom-scopes`, to pass in high-precendence spack configuration
* Updated guidance on `spack.specs`

## The PR

- **Update workflow, manifest, config for v8**
- **Update README guidance for v8**
